### PR TITLE
Add GoStatic article

### DIFF
--- a/source/_articles/automatic-preview-urls-for-jigsaw.md
+++ b/source/_articles/automatic-preview-urls-for-jigsaw.md
@@ -1,6 +1,0 @@
----
-title: "Automatic preview URLs for Jigsaw"
-author: Jon Milsom
-url: https://www.deploywizard.com/jigsaw-preview-urls/
-published: 2021-01-21
----

--- a/source/_articles/deploy-jigsaw-using-github-actions.md
+++ b/source/_articles/deploy-jigsaw-using-github-actions.md
@@ -1,0 +1,6 @@
+---
+title: "Deploy Jigsaw using GitHub Actions and GoStatic"
+author: Jon Milsom
+url: https://www.gostaticapp.com/jigsaw-github-action
+published: 2021-02-19
+---


### PR DESCRIPTION
PR to add an article which shows how to build Jigsaw using GitHub actions, and deploy using GoStatic.
GoStatic automatically generates a URL for the uploaded static site and takes less than 10 seconds to deploy.

Example URL:
https://60aem0nf31revr5q.gostatic.app/

Article:
https://www.gostaticapp.com/jigsaw-github-action

(I have also removed a link to my other project DeployWizard, which now seems over-engineered for static sites).

![Screenshot 2021-02-19 at 11 24 11](https://user-images.githubusercontent.com/488695/108499089-b3676480-72a5-11eb-9500-4d20c48c5123.png)


- [ ] This is adding a new web site to BuiltWithJigsaw
- [x] This is not a new web site, but something else 

If this is adding a new web site:

- [ ] I have created a screenshot
- [ ] The screenshot is sized 380x210
- [ ] The screenshot is saved with PNG-8, not PNG-24, and I've run it through an image optimization tool like [ImageOptim](https://imageoptim.com/mac)
- [ ] I saved the screenshot with the same filename as my site's `.md` file, but as a `.png` instead
- [ ] I saved the screenshot in the `/source/assets/images/sites` directory
- [ ] I built the site locally to ensure it looks right
