### PR TITLE
Remove: how-i-deploy-my-jigsaw article

### DIFF
--- a/source/_articles/how-i-deploy-my-jigsaw-blog-to-github-pages.md
+++ b/source/_articles/how-i-deploy-my-jigsaw-blog-to-github-pages.md
@@ -1,6 +1,0 @@
----
-title: "How I deploy my Jigsaw blog to GitHub Pages"
-author: Martin Betz
-url: https://martinbetz.eu/articles/jigsaw-github-pages/
-published: 2020-01-28
----


### PR DESCRIPTION
Hi,

I still receive a lot of links from builtwithjigsaw to a broken and outdated article of mine.
Please remove! Thanks.

https://github.com/tighten/builtwithjigsaw/blob/909dcb188316624cbdeb1e6da2c5806cc2469108/source/_articles/how-i-deploy-my-jigsaw-blog-to-github-pages.md

You can check martinbetz.eu to double check that I am the owner of this article. I also created the initial PR to add the article.